### PR TITLE
Feature/avg bagel scaled bfs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update && \
   libblas-dev \
   libssl-dev \
   libssh2-1-dev \
+  libnlopt-dev \
   r-base \
   r-base-dev \
   python3  \

--- a/main.nf
+++ b/main.nf
@@ -759,7 +759,7 @@ workflow BAGEL_bf {
     bagel_sgrna = BAGEL_bf_sgrna( matrices_for_correction, analysis_indices, 'sgrna' )
 
     // Scale BAGEL gene BFs
-    scale_gene_BFs( bagel_gene, analysis_indices)
+    scale_gene_BFs( bagel_sgrna, analysis_indices)
 
   emit:
     bagel_gene

--- a/modules/BAGEL2/common.nf
+++ b/modules/BAGEL2/common.nf
@@ -134,7 +134,7 @@ process scale_gene_BFs {
   publishDir "${params.resultDir}/BAGEL2/${contrast}/scaled", mode: 'copy', pattern: '*scaled*', overwrite: true
 
   input:
-    tuple val( contrast ), file( bagel_bf_gene )
+    tuple val( contrast ), file( bagel_bf_sgrna )
     val( analysis_indices )
 
   output:
@@ -151,15 +151,17 @@ process scale_gene_BFs {
     script_path = "${baseDir}/submodules/rcrispr/exec/scale_lfcs_and_bfs.R"
     analysis_suffix = "BF.${contrast}"
 
+    treatment_index_values = analysis_indices["${contrast}"]["lfc"]["base1"]
+
     cmd = "${params.rscript_exec} ${script_path}"
     cmd = "${cmd} --is_bf"
     cmd = "${cmd} --threshold ${params.scaled_bf_threshold}"
 
-    cmd = "${cmd} --infile \"${bagel_bf_gene}\""
+    cmd = "${cmd} --infile \"${bagel_bf_sgrna}\""
     cmd = ( params.scaled_bf_infile_header ) ? cmd : "${cmd} --no_infile_header"
     cmd = "${cmd} --infile_delim \"${params.scaled_bf_infile_delim}\""
     cmd = "${cmd} --infile_gene_column_index ${params.scaled_bf_infile_gene_column_index}"
-    cmd = "${cmd} --infile_data_column_index \"${params.scaled_bf_infile_data_column_index}\""
+    cmd = "${cmd} --infile_data_column_index \"${treatment_index_values}\""
 
     cmd = "${cmd} --ess \"${params.essential_genes}\""
     cmd = "${cmd} --ess_gene_column_index ${params.ess_gene_column_index}"

--- a/modules/BAGEL2/config/common
+++ b/modules/BAGEL2/config/common
@@ -45,7 +45,6 @@ params {
     scaled_bf_outdir = "."
     scaled_bf_infile_id_column_index = null
     scaled_bf_infile_gene_column_index = 1
-    scaled_bf_infile_data_column_index = 2
     scaled_bf_infile_delim = "\t"
     scaled_bf_infile_header = true
     scaled_bf_rdata = "scaled_BF.Rdata"


### PR DESCRIPTION
* Update RCRISPR submodule to 1.2.0.0
* Remove option for data column parameter for scale BFs
* Use BAGEL sgRNA BFs as input for `scale_gene_BFs` process
* Use treatment indices (LFC) to set number of data columns