### PR TITLE
Feature/updates for qc and bf scaling

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -348,7 +348,8 @@ def get_analysis_indices( sample_totals ) {
                                                                         'base1': ( 1..n_control ).join( ',' ),
                                                                         'base1_increment1': ( 2..(1 + n_control) ).join( ',' ),
                                                                         'base1_increment2': ( 3..(2 + n_control) ).join( ',' ),
-                                                                        'base1_scaled_lfc': ( 2..(n_control - 1) ).join( ',' ) ]
+                                                                        'base1_scaled_lfc': ( 2..(n_control - 1) ).join( ',' ) ],
+                                                  'bf':             [   'base1': ( 3..(3 + (n_control - 1)) ).join( ',' ) ]                      
                                                 ] ]
   }
   if ( n_plasmid > 0 && n_treatment > 0 ) {
@@ -362,7 +363,8 @@ def get_analysis_indices( sample_totals ) {
                                                                             'base1': ( 1..n_treatment ).join( ',' ),
                                                                             'base1_increment2': ( 3..(2 + n_treatment) ).join( ',' ),
                                                                             'base1_increment1': ( 2..(1 + n_treatment) ).join( ',' ),
-                                                                            'base1_scaled_lfc': ( 2..(n_treatment - 1) ).join( ',' ) ] ] ]
+                                                                            'base1_scaled_lfc': ( 2..(n_treatment - 1) ).join( ',' ) ],
+                                                    'bf':               [   'base1': ( 3..(3 + (n_treatment - 1)) ).join( ',' ) ] ] ]
   }
   if ( n_control > 0 && n_treatment > 0 ) {
     n_contrasts++
@@ -375,7 +377,8 @@ def get_analysis_indices( sample_totals ) {
                                                                             'base1': ( 1..n_treatment ).join( ',' ),
                                                                             'base1_increment2': ( 3..(2 + n_treatment) ).join( ',' ),
                                                                             'base1_increment1': ( 2..(1 + n_treatment) ).join( ',' ),
-                                                                            'base1_scaled_lfc': ( 2..(n_treatment - 1) ).join( ',' ) ] ] ]
+                                                                            'base1_scaled_lfc': ( 2..(n_treatment - 1) ).join( ',' ) ],
+                                                    'bf':               [   'base1': ( 3..(3 + (n_treatment - 1)) ).join( ',' ) ] ] ]
   }
   analysis_indices <<  [ 'n_contrasts': n_contrasts ]
   return analysis_indices

--- a/modules/BAGEL2/common.nf
+++ b/modules/BAGEL2/common.nf
@@ -151,7 +151,7 @@ process scale_gene_BFs {
     script_path = "${baseDir}/submodules/rcrispr/exec/scale_lfcs_and_bfs.R"
     analysis_suffix = "BF.${contrast}"
 
-    treatment_index_values = analysis_indices["${contrast}"]["lfc"]["base1"]
+    treatment_index_values = analysis_indices["${contrast}"]["bf"]["base1"]
 
     cmd = "${params.rscript_exec} ${script_path}"
     cmd = "${cmd} --is_bf"


### PR DESCRIPTION
* Update RCRISPR to 1.2.1.0
* Add and modify data column indices for BF scaling
* Fix to allow PCA shape without plasmid/groups